### PR TITLE
Add non-normative IACD references (HTTPS-8)

### DIFF
--- a/openc2-impl-https-v1.0.md
+++ b/openc2-impl-https-v1.0.md
@@ -129,6 +129,8 @@ Trammell, B., "Transport of Real-time Inter-network Defense (RID) Messages over 
 Sheffer, Y., Holz, R., and P. Saint-Andre, "Recommendations for Secure Use of Transport Layer Security (TLS) and Datagram Transport Layer Security (DTLS)", BCP 195, RFC 7525, DOI 10.17487/RFC7525, May 2015, <https://www.rfc-editor.org/info/rfc7525>.
 ###### [SLPF]
 _Open Command and Control (OpenC2) Profile for Stateless Packet Filtering Version 1.0_. Edited by Joe Brule, Duncan Sparrell and Alex Everett. Latest version: http://docs.oasis-open.org/openc2/oc2slpf/v1.0/oc2slpf-v1.0.html 
+###### [IACD]
+M. J. Herring, K. D. Willett, "Active Cyber Defense: A Vision for Real-Time Cyber Defense," Journal of Information Warfare, vol. 13, Issue 2, p. 80, April 2014.<br>Willett, Keith D., "Integrated Adaptive Cyberspace Defense: Secure Orchestration", International Command and Control Research and Technology Symposium, June 2015.
 
 ## 1.5 Document Conventions
 The following color, font and font style conventions are used in this document:


### PR DESCRIPTION
Address issue #16 

Adds two IACD documents as a  non-normative reference.