### PR TITLE
specify base64url encoding for X-Correlation-ID (HTTPS-29)

### DIFF
--- a/openc2-impl-https-v1.0.md
+++ b/openc2-impl-https-v1.0.md
@@ -281,6 +281,8 @@ Each HTTP message body MUST contain only a single OpenC2 command or response mes
 
 All HTTP request and response messages containing OpenC2 payloads SHOULD include the "Cache-control:" header with a value of "no-cache".
 
+The HTTP X-Correlation-ID header SHALL be populated with the base64url encoding of the OpenC2 binary request_id.
+
 ### 3.2.3 TLS Usage
 HTTPS, the transmission of HTTP over TLS, is specified in Section 2 of [[RFC2818](#rfc2818)]. OpenC2 endpoints MUST accept TLS version 1.2 [[RFC5246](#rfc5246)] connections or higher for confidentiality, identification, and authentication when sending OpenC2 messages over HTTPS, and SHOULD accept TLS Version 1.3 [[RFC8446](#rfc8446)] or higher connections.
 
@@ -376,7 +378,7 @@ A conformant implementation of this transfer specification MUST:
 | content | JSON verbose serialization of OpenC2 commands and responses carried in the HTTP message body |
 | content_type /<br>msg_type | Combined and carried in the HTTP Content-type and Accepted headers:<br>    Command:  application/openc2-cmd+json;version=1.0<br>    Response:  application/openc2-rsp+json;version=1.0 |
 | status | Numeric status code supplied by OpenC2 Consumers is carried in the HTTP Response start line status code.  |
-| request_id | Valued supplied by OpenC2 Producers is carried in HTTP X-Correlation-ID header and delivered to recipient along with OpenC2 command. |
+| request_id | base64url-encoded value supplied by OpenC2 Producers is carried in HTTP X-Correlation-ID header and delivered to recipient along with OpenC2 command. |
 | created | Carried in the HTTP Date header |
 | from | Populated with the authenticated identity of the peer entity, consistent with the configured authentication scheme. |
 | to | Carried in the HTTP Host header |


### PR DESCRIPTION
Addresses issue #54. 

Added new requirement in section 3.2.2 and clarifying language in section 4.1 message elements table.